### PR TITLE
update example usage command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ mvn install
 When the archetype has been installed locally you can create a project using the command below. Just replace the parameter values with the actual values you want to use.
 
 ``` shell
- mvn archetype:generate -DarchetypeGroupId=com.deangerber.archetypes
-                        -DarchetypeArtifactId=java11-junit5-archetype
-                        -DarchetypeVersion=1.0.0-SNAPSHOT
-                        -DgroupId=com.deangerber.kata.stringcalculator
-                        -DartifactId=stringcalculator
-                        -Dversion=1.0.0-SNAPSHOT
+ mvn archetype:generate -DarchetypeGroupId=com.deangerber.archetypes \
+                        -DarchetypeArtifactId=java11-junit5-archetype \
+                        -DarchetypeVersion=1.0.0-SNAPSHOT \
+                        -DgroupId=com.deangerber.kata.stringcalculator \
+                        -DartifactId=stringcalculator \
+                        -Dversion=1.0.0-SNAPSHOT \
                         -DinteractiveMode=false
 ```
 


### PR DESCRIPTION
The example usage command in the readme doesn't work out of the box, as it's written because the line breaks aren't escaped.
```
mvn archetype:generate -DarchetypeGroupId=com.deangerber.archetypes
                                                                -DarchetypeArtifactId=java11-junit5-archetype
                                                                -DarchetypeVersion=1.0.0-SNAPSHOT
                                                                -DgroupId=com.deangerber.kata.stringcalculator
                                                                -DartifactId=stringcalculator
                                                                -Dversion=1.0.0-SNAPSHOT
                                                                -DinteractiveMode=false
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< org.apache.maven:standalone-pom >-------------------
[INFO] Building Maven Stub Project (No POM) 1
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] >>> maven-archetype-plugin:3.2.0:generate (default-cli) > generate-sources @ standalone-pom >>>
[INFO] 
[INFO] <<< maven-archetype-plugin:3.2.0:generate (default-cli) < generate-sources @ standalone-pom <<<
[INFO] 
[INFO] 
[INFO] --- maven-archetype-plugin:3.2.0:generate (default-cli) @ standalone-pom ---
[INFO] Generating project in Interactive mode
[WARNING] No archetype found in remote catalog. Defaulting to internal catalog
[INFO] No archetype defined. Using maven-archetype-quickstart (com.deangerber.archetypes:maven-archetype-quickstart:1.0)
Choose archetype:
1: internal -> org.apache.maven.archetypes:maven-archetype-archetype (An archetype which contains a sample archetype.)
2: internal -> org.apache.maven.archetypes:maven-archetype-j2ee-simple (An archetype which contains a simplifed sample J2EE application.)
3: internal -> org.apache.maven.archetypes:maven-archetype-plugin (An archetype which contains a sample Maven plugin.)
4: internal -> org.apache.maven.archetypes:maven-archetype-plugin-site (An archetype which contains a sample Maven plugin site.
      This archetype can be layered upon an existing Maven plugin project.)
5: internal -> org.apache.maven.archetypes:maven-archetype-portlet (An archetype which contains a sample JSR-268 Portlet.)
6: internal -> org.apache.maven.archetypes:maven-archetype-profiles ()
7: internal -> org.apache.maven.archetypes:maven-archetype-quickstart (An archetype which contains a sample Maven project.)
8: internal -> org.apache.maven.archetypes:maven-archetype-site (An archetype which contains a sample Maven site which demonstrates
      some of the supported document types like APT, XDoc, and FML and demonstrates how
      to i18n your site. This archetype can be layered upon an existing Maven project.)
9: internal -> org.apache.maven.archetypes:maven-archetype-site-simple (An archetype which contains a sample Maven site.)
10: internal -> org.apache.maven.archetypes:maven-archetype-webapp (An archetype which contains a sample Maven Webapp project.)
11: local -> com.deangerber.archetypes:java11-junit5-archetype (Archetype used to generate basic JAVA 11 and JUnit 5 application)
Choose a number or apply filter (format: [groupId:]artifactId, case sensitive contains): : 
```

This PR escapes the line breaks so that the command works when exactly copy/pasted
```
mvn archetype:generate -DarchetypeGroupId=com.deangerber.archetypes \
                                                                -DarchetypeArtifactId=java11-junit5-archetype \
                                                                -DarchetypeVersion=1.0.0-SNAPSHOT \
                                                                -DgroupId=com.deangerber.kata.stringcalculator \
                                                                -DartifactId=stringcalculator \
                                                                -Dversion=1.0.0-SNAPSHOT \
                                                                -DinteractiveMode=false
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< org.apache.maven:standalone-pom >-------------------
[INFO] Building Maven Stub Project (No POM) 1
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] >>> maven-archetype-plugin:3.2.0:generate (default-cli) > generate-sources @ standalone-pom >>>
[INFO] 
[INFO] <<< maven-archetype-plugin:3.2.0:generate (default-cli) < generate-sources @ standalone-pom <<<
[INFO] 
[INFO] 
[INFO] --- maven-archetype-plugin:3.2.0:generate (default-cli) @ standalone-pom ---
[INFO] Generating project in Batch mode
[WARNING] No archetype found in remote catalog. Defaulting to internal catalog
[INFO] Archetype repository not defined. Using the one from [com.deangerber.archetypes:java11-junit5-archetype:1.0.0-SNAPSHOT] found in catalog local
[INFO] ----------------------------------------------------------------------------
[INFO] Using following parameters for creating project from Archetype: java11-junit5-archetype:1.0.0-SNAPSHOT
[INFO] ----------------------------------------------------------------------------
[INFO] Parameter: groupId, Value: com.deangerber.kata.stringcalculator
[INFO] Parameter: artifactId, Value: stringcalculator
[INFO] Parameter: version, Value: 1.0.0-SNAPSHOT
[INFO] Parameter: package, Value: com.deangerber.kata.stringcalculator
[INFO] Parameter: packageInPathFormat, Value: com/deangerber/kata/stringcalculator
[INFO] Parameter: package, Value: com.deangerber.kata.stringcalculator
[INFO] Parameter: groupId, Value: com.deangerber.kata.stringcalculator
[INFO] Parameter: artifactId, Value: stringcalculator
[INFO] Parameter: version, Value: 1.0.0-SNAPSHOT
[INFO] Project created from Archetype in dir: /Users/zjgoodma/git/magic-square/stringcalculator
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.546 s
[INFO] Finished at: 2020-09-18T14:36:04-05:00
[INFO] ------------------------------------------------------------------------
```